### PR TITLE
Fix capitalization on website header

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>Ccss by sathify</title>
+    <title>CCSS by sathify</title>
 
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/pygment_trac.css">
@@ -16,7 +16,7 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1 class="header">Ccss</h1>
+        <h1 class="header">CCSS</h1>
         <p class="header">CSS architecture for web applications</p>
 
         <ul>


### PR DESCRIPTION
Awesome work, I'm stealing this for my next project!

The README is pretty consistent about using the ``CCSS'' capitalization, so it probably makes sense to do so on the intro website as well.

Will hopefully have a more substantial contribution soon (if the project maintainers end up being nice people, anyway :wink:).
